### PR TITLE
Clamp max radius

### DIFF
--- a/lib/src/processed_smooth_radius.dart
+++ b/lib/src/processed_smooth_radius.dart
@@ -1,4 +1,5 @@
 import 'dart:math' as math;
+
 import 'package:vector_math/vector_math.dart' as vector;
 
 import 'smooth_radius.dart';
@@ -77,7 +78,10 @@ class ProcessedSmoothRadius {
       p: p,
       width: width,
       height: height,
-      radius: radius,
+      radius: SmoothRadius(
+        cornerRadius: cornerRadius,
+        cornerSmoothing: radius.cornerSmoothing,
+      ),
       circularSectionLength: circularSectionLength,
     );
   }


### PR DESCRIPTION
Fixes an issue when we set a cornerRadius which is more than the maximum allowed. Resulting in ugly results.

Before : 
![Simulator Screen Shot - iPhone 13 Pro - 2022-06-09 at 17 43 56](https://user-images.githubusercontent.com/9378033/172889339-51c19de1-887f-4a41-b11d-dd42d54fb5d8.png)

With this fix : 
![Simulator Screen Shot - iPhone 13 Pro - 2022-06-09 at 17 44 23](https://user-images.githubusercontent.com/9378033/172889387-31dfd700-a4ab-4f86-bf3f-e27b37701328.png)

